### PR TITLE
Providing access to username in conn

### DIFF
--- a/lib/access_pass/gate_keeper.ex
+++ b/lib/access_pass/gate_keeper.ex
@@ -82,7 +82,7 @@ defmodule AccessPass.GateKeeper do
 
   def log_in(username, password) do
     case login(username, password) do
-      {:ok, user} -> {:ok, RefreshToken.add(user.id, user.meta, refresh_expire_in())}
+      {:ok, user} -> {:ok, RefreshToken.add(user.id, %{username: user.username, meta: user.meta}, refresh_expire_in())}
       {:error} -> {:error, "username or password is incorrect"}
     end
   end

--- a/lib/access_pass/plug.ex
+++ b/lib/access_pass/plug.ex
@@ -14,7 +14,7 @@ defmodule AccessPass.Auth do
     token = conn |> getHeaderValue("access_token")
 
     case AccessPass.logged?(token) do
-      {:ok, meta} -> conn |> assign(:meta, meta)
+      {:ok, data} -> conn |> assign(:data, data)
       {:error, _} -> conn |> send_resp(401, "unauthorized") |> halt()
     end
   end


### PR DESCRIPTION
So I took a shot at doing this (#1), and the simplest solution seemed to be to store the username in the meta field in the genserver and put this in the `conn` object in the `plug`. Then in my code, I can do `conn.assigns[:data][:username]` to retrieve the user name and then retrieve the rest of the details from the database. It's not the most elegant solution, but it seems to work.

The ideal case would be to be able to retrieve the ecto user model directly from the `conn` similar to that in the coherence library. But this requires that accesspass use the same Ecto model as the main project instead of having it's own Ecto model.