### PR TITLE
Add forgot_username to the documentation.

### DIFF
--- a/doc_extras/getting_started.md
+++ b/doc_extras/getting_started.md
@@ -126,6 +126,8 @@ The above will add endpoints for:
  POST /logout
 
  POST /change_password
+
+ POST /forgot_username
      
  For more information on the above routes jump ahead to Phoenix routes section of crash course.    
  

--- a/doc_extras/phoenix_routes_helper.md
+++ b/doc_extras/phoenix_routes_helper.md
@@ -144,3 +144,21 @@ password resets expire 2 hours after sent.
 }       
 ```
 
+### POST /forgot_username
+
+This endpoint is used to have a user's forgotten username emailed to them.
+
+<b>Required Params</b>
+
+<b>body</b>: 
+
+```json
+{ 
+  "email"   : "email",
+}       
+```
+<b>Returns:</b>
+
+```json
+	{"ok": "An email has been sent to you with your username"}
+```

--- a/lib/access_pass/routes.ex
+++ b/lib/access_pass/routes.ex
@@ -19,6 +19,8 @@ defmodule AccessPass.Routes do
 
      POST /change_password
 
+     POST /forgot_username
+
      usage:
      ```elixir
     defmodule TestWeb.Router do


### PR DESCRIPTION
I noticed this feature was missing from the documentation.