### PR TITLE
Add derive for user primary_key

### DIFF
--- a/lib/access_pass/users.ex
+++ b/lib/access_pass/users.ex
@@ -7,6 +7,7 @@ defmodule AccessPass.Users do
   alias AccessPass.GateKeeper
   import AccessPass.Config
   @primary_key {:user_id, :string, autogenerate: false}
+  @derive {Phoenix.Param, key: :user_id}
   schema "users" do
     field(:username, :string)
     field(:meta, :map, default: %{})
@@ -61,6 +62,7 @@ defmodule AccessPass.Users do
       _ -> add_error(changeset, :password_confirm, "Password fields do not match")
     end
   end
+
   def compare_passwords(cs), do: cs
 
   def update_password(changeset, params) do


### PR DESCRIPTION
I'm building an admin interface / controller for users and hit this issue when writing tests:

** (ArgumentError) structs expect an :id key when converting to_param or a custom implementation of the Phoenix.Param protocol (read Phoenix.Param docs for more information),
got: %AccessPass.Users{__meta__: #Ecto.Schema.Metadata<:loaded, "users">, confirm_id: nil, confirmed: false, email: "email-8@example.com", inserted_at: ~N[2018-10-07 03:45:06.795498], meta: %{role: "admin"}, password: "password123", password_confirm: "password123", password_hash: "$2b$12$XxbFDjXpn4VeW0JV/1hVlOaGr1AGdTpHRRYTcElyA8/g.SgxuQLU2", password_reset_expire: nil, password_reset_key: nil, successful_login_attempts: 1, updated_at: ~N[2018-10-07 03:45:06.795510], user_id: "8", username: "user-8"}

This is caused by using the `user_id` field instead of an `id` field as the primary key.  From [the Phoenix docs](https://hexdocs.pm/phoenix/Phoenix.Param.html) I think the correct fix is adding this `@derive` protocol to the user schema.